### PR TITLE
chore(repo): add CODEOWNERS, CodeQL scanning, and oss readiness

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Default owner for everything
+*                       @pudgestudio
+
+# Spec content (the product) — keep a tight review loop
+/spec/                  @pudgestudio @uskhokhar
+
+# MCP server (published to npm)
+/packages/mcp-server/   @pudgestudio @uskhokhar
+
+# CI / release plumbing
+/.github/               @pudgestudio 

--- a/.github/codeql.yml
+++ b/.github/codeql.yml
@@ -1,0 +1,16 @@
+name: CodeQL
+on:
+  push: { branches: [main] }
+  pull_request: { branches: [main] }
+  schedule: [{ cron: "0 6 * * 1" }]   # weekly
+permissions:
+  contents: read
+  security-events: write
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with: { languages: javascript-typescript }
+      - uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ docs/             documentation site (ui.pudgestudio.com)
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
+## License & brand
+
+Code and component specs are [MIT](LICENSE). The **pudge-ui** name, the **Pudge** capybara mascot,
+and the logo are trademarks of Pudge Studio and are **not** covered by the MIT license — please
+don't use them to imply endorsement or for a fork's branding.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION

## What's in this PR

Three unrelated but cohesive repo-hygiene changes — no spec, MCP, or docs content touched.

### Added

- **`.github/CODEOWNERS`** — default owner `@pudgestudio` for the whole repo; tighter review loop
  on `/spec/` and `/packages/mcp-server/` (both `@pudgestudio @uskhokhar`); CI/release plumbing
  scoped to `@pudgestudio`.
- **`.github/codeql.yml`** — CodeQL security-scanning workflow for JS/TS. Runs on every push to
  `main`, every PR targeting `main`, and weekly (Monday 06:00 UTC). Requires
  `security-events: write` permission; everything else is `read`.

### Changed

- **`README.md`** — new "License & brand" section (inserted above the existing bare "License"
  heading) clarifying that MIT covers code and component specs, while the **pudge-ui** name, the
  **Pudge** capybara mascot, and the logo are Pudge Studio trademarks not covered by the MIT
  license.

## Scope / risk

- No spec content, MCP tool, or docs page changed.
- CODEOWNERS takes effect on the next PR; no existing process is broken.
- CodeQL runs in a read-only analysis job; no deploy or publish side-effects.
- README change is documentation only.

## Files changed

| File | Change |
|------|--------|
| `.github/CODEOWNERS` | New |
| `.github/codeql.yml` | New |
| `README.md` | +6 lines (License & brand section) |
